### PR TITLE
Set opacity=0 instead of removing and allow to reverse this on toggle

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,16 +1,37 @@
-const code = `(() => {
+const hide = `(() => {
   const elements = document.querySelectorAll('body *')
   for (let i = 0; i < elements.length; i++) {
     const el = elements[i]
     const pos = window.getComputedStyle(el).position
     if (pos === 'fixed' || pos === 'sticky') {
-      el.parentNode.removeChild(el)
+      el.dataset["killStickyOriginalOpacity"] = el.style.opacity
+      el.style["opacity"] = "0"
     }
   }
   document.body.style.overflow = 'visible'
   document.documentElement.style.overflow = 'visible'
 })()`
 
+const show = `(() => {
+  const elements = document.querySelectorAll('[data-kill-sticky-original-opacity]')
+  for (const el of elements) {
+    const originalOpacity = el.dataset["killStickyOriginalOpacity"];
+    if (originalOpacity === "") {
+      el.style["opacity"] = null;
+    } else {
+      el.style.opacity = originalOpacity
+    }
+    delete el.dataset.killStickyOriginalOpacity
+  }
+})()`
+
+let hidden = false;
 chrome.browserAction.onClicked.addListener(() => {
-  chrome.tabs.executeScript({ code })
+  if (hidden) {
+    chrome.tabs.executeScript({ code: show })
+    hidden = false;
+  } else {
+    chrome.tabs.executeScript({ code: hide })
+    hidden = true;
+  }
 })


### PR DESCRIPTION
I've modified the logic to set the elements opacity instead of removing it from the DOM. To be able to reverse this operation, the previous opacity is stored in a data attribute: `data-kill-sticky-original-opacity` on the element. 

Additionally, I added a toggle logic so that clicking the extension icon again will show/hide the elements.

Let me know what you think. Instead of the opacity, one could also set the `top, left` to very large negative values to move them out of screen and bring them back by storing the original offsets in a data attribute.