### PR TITLE
Only hides visible elements, to fix problems with sites like Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 A Chrome Extension based on the [Kill sticky headers](https://alisdair.mcdiarmid.org/kill-sticky-headers/) bookmarklet by Alisdair McDiarmid, this adds a keyboard shortcut (**Ctrl+Shift+K** on Windows & Linux, **Cmd+K** on macOS) that runs this bit of JavaScript on the current page:
 
 ```js
-const elements = document.querySelectorAll('body *')
-for (let i = 0; i < elements.length; i++) {
-  const el = elements[i]
-  const pos = window.getComputedStyle(el).position
-  if (pos === 'fixed' || pos === 'sticky') {
-    el.parentNode.removeChild(el)
-  }
-}
+ const elements = document.querySelectorAll('body *')
+ for (let i = 0; i < elements.length; i++) {
+   const el = elements[i]
+   const pos = window.getComputedStyle(el).position
+   const style = window.getComputedStyle(el);
+   if ((pos === 'fixed' || pos === 'sticky') && style.display !== 'none') {
+     el.parentNode.removeChild(el)
+   }
+ }
+ document.body.style.overflow = 'visible'
+ document.documentElement.style.overflow = 'visible'
 ```
 
 To change the keyboard shortcut, visit the page [`chrome://extensions/shortcuts`](chrome://extensions/shortcuts).

--- a/background.js
+++ b/background.js
@@ -2,9 +2,8 @@ const code = `(() => {
   const elements = document.querySelectorAll('body *')
   for (let i = 0; i < elements.length; i++) {
     const el = elements[i]
-    const pos = window.getComputedStyle(el).position
-	const style = window.getComputedStyle(el);
-    if ((pos === 'fixed' || pos === 'sticky') && style.display !== 'none') {
+    const computedStyle = window.getComputedStyle(el);
+    if ((computedStyle.position === 'fixed' || computedStyle.position === 'sticky') && computedStyle.display !== 'none') {
       el.parentNode.removeChild(el)
     }
   }

--- a/background.js
+++ b/background.js
@@ -3,7 +3,8 @@ const code = `(() => {
   for (let i = 0; i < elements.length; i++) {
     const el = elements[i]
     const pos = window.getComputedStyle(el).position
-    if (pos === 'fixed' || pos === 'sticky') {
+	const style = window.getComputedStyle(el);
+    if ((pos === 'fixed' || pos === 'sticky') && style.display !== 'none') {
       el.parentNode.removeChild(el)
     }
   }


### PR DESCRIPTION
A lot of websites break once you hide sticky elements. For example, once you hide the sticky elements, Twitter will not be able to show tweets, because the overlay is considered sticky. This is a really simple fix that just checks to make sure the element is visible before hiding it. I've used it for about a week now to test it and so far it hasn't failed to hide something that I want hidden (this doesn't really seem to cause false negatives).